### PR TITLE
fixed: redirect user back after login as this can be the reason for t…

### DIFF
--- a/mod/event_calendar/models/model.php
+++ b/mod/event_calendar/models/model.php
@@ -1884,8 +1884,9 @@ function event_calendar_get_page_content_view($event_guid,$light_box = FALSE) {
 	$event = get_entity($event_guid);
 
 	if (!elgg_instanceof($event, 'object', 'event_calendar')) {
-		$content = elgg_echo('event_calendar:error_nosuchevent');
-		$title = elgg_echo('event_calendar:generic_error_title');
+		register_error(elgg_echo('noaccess'));
+		$_SESSION['last_forward_from'] = current_page_url();
+		forward('');
 	} else {
 		$title = htmlspecialchars($event->title);
 		$event_container = get_entity($event->container_guid);

--- a/mod/polls/models/model.php
+++ b/mod/polls/models/model.php
@@ -344,11 +344,9 @@ function polls_get_page_view($guid) {
 		}
 		elgg_push_breadcrumb($poll->title);
 	} else {			
-		// Display the 'post not found' page instead
-		$title = elgg_echo("polls:notfound");	
-		$content = elgg_view("polls/notfound");	
-		elgg_push_breadcrumb(elgg_echo('item:object:poll'), "polls/all");
-		elgg_push_breadcrumb($title);
+		register_error(elgg_echo('noaccess'));
+		$_SESSION['last_forward_from'] = current_page_url();
+		forward('');
 	}
 	
 	$params = array('title' =>$title,'content' => $content,'filter'=>'');

--- a/mod/tasks/pages/tasks/history.php
+++ b/mod/tasks/pages/tasks/history.php
@@ -9,12 +9,16 @@ $task_guid = get_input('guid');
 
 $task = get_entity($task_guid);
 if (!$task) {
-
+    register_error(elgg_echo('noaccess'));
+    $_SESSION['last_forward_from'] = current_page_url();
+    forward('');
 }
 
 $container = $task->getContainerEntity();
 if (!$container) {
-
+    register_error(elgg_echo('noaccess'));
+    $_SESSION['last_forward_from'] = current_page_url();
+    forward('');
 }
 
 elgg_set_page_owner_guid($container->getGUID());

--- a/mod/tasks/pages/tasks/revision.php
+++ b/mod/tasks/pages/tasks/revision.php
@@ -8,12 +8,16 @@
 $id = get_input('id');
 $annotation = elgg_get_annotation_from_id($id);
 if (!$annotation) {
-	forward();
+    register_error(elgg_echo('noaccess'));
+    $_SESSION['last_forward_from'] = current_page_url();
+    forward('');
 }
 
 $task = get_entity($annotation->entity_guid);
 if (!$task) {
-	
+    register_error(elgg_echo('noaccess'));
+    $_SESSION['last_forward_from'] = current_page_url();
+    forward('');
 }
 
 elgg_set_page_owner_guid($task->getContainerGUID());

--- a/mod/tasks/pages/tasks/view.php
+++ b/mod/tasks/pages/tasks/view.php
@@ -8,7 +8,9 @@
 $task_guid = get_input('guid');
 $task = get_entity($task_guid);
 if (!$task) {
-	forward();
+	register_error(elgg_echo('noaccess'));
+	$_SESSION['last_forward_from'] = current_page_url();
+	forward('');
 }
 
 elgg_set_page_owner_guid($task->getContainerGUID());


### PR DESCRIPTION
This hopefully should fix #100. Not sure all the cases are handled but at least the problem is fixed for the following content types:
- (Calendar) events
- Polls
- Tasks

Also tested the following types, but did not find any redirect issues:
- Activity
- Groups
- Blogs
- Bookmarks
- Files
- The Wire
- Photos