### PR TITLE
Mission share to wire - Now consistent with the rest of the site

### DIFF
--- a/mod/missions/actions/missions/wire-post.php
+++ b/mod/missions/actions/missions/wire-post.php
@@ -9,7 +9,7 @@
 
 /*
  * Posts a mission notice to The Wire.
- */
+ 
 $message = get_input('wire_message');
 $char_limit = (int)elgg_get_plugin_setting('limit', 'thewire');
 
@@ -23,3 +23,57 @@ else {
 	system_message(elgg_echo('missions:posted_to_the_wire'));
 	forward(elgg_get_site_url() . 'missions/main');
 }
+Nick - Replacing the old share on the wire tools action
+*/
+
+$body = get_input("body", "", false);
+
+$access_id = (int) get_input("access_id", ACCESS_PUBLIC);
+$method = "site";
+$parent_guid = (int) get_input("parent_guid");
+$reshare_guid = (int) get_input("reshare_guid");
+
+// make sure the post isn't blank
+if (empty($body)) {
+	register_error(elgg_echo("thewire:blank"));
+	forward(REFERER);
+}
+
+$guid = thewire_tools_save_post($body, elgg_get_logged_in_user_guid(), $access_id, $parent_guid, $method, $reshare_guid);
+if (!$guid) {
+	register_error(elgg_echo("thewire:error"));
+	forward(REFERER);
+}
+
+// if reply, forward to thread display page
+if ($parent_guid) {
+	$parent = get_entity($parent_guid);
+	forward("thewire/thread/$parent->wire_thread");
+}
+
+// cyu - send notifications when a user shares your content on the wire
+if ($reshare_guid || $reshare_guid > 0) {
+	$content_owner = get_entity($reshare_guid)->getOwnerEntity();
+	$entity = get_entity($reshare_guid);
+	$wire_entity = get_entity($guid);
+
+	if ($entity->getType() == 'group'){
+		$entity->title = $entity->name;
+	}
+
+	// cyu - if cp notification plugin is active, use that for notifications
+	if (elgg_is_active_plugin('cp_notifications')) {
+		$message = array(
+			'cp_msg_type' => 'cp_wire_share',
+			'cp_recipient' => $entity->getOwnerEntity(),
+			'cp_shared_by' => elgg_get_logged_in_user_entity(),
+			'cp_content' => $entity,
+			'cp_wire_url' => $wire_entity->getURL(),
+		);
+		elgg_trigger_plugin_hook('cp_overwrite_notification','all',$message);
+	}
+}
+
+//Take them back to the missions screen
+system_message(elgg_echo('missions:posted_to_the_wire'));
+forward(elgg_get_site_url() . 'missions/main');

--- a/mod/missions/actions/missions/wire-post.php
+++ b/mod/missions/actions/missions/wire-post.php
@@ -6,25 +6,7 @@
  * License: Creative Commons Attribution 3.0 Unported License
  * Copyright: Her Majesty the Queen in Right of Canada, 2015
  */
-
-/*
- * Posts a mission notice to The Wire.
- 
-$message = get_input('wire_message');
-$char_limit = (int)elgg_get_plugin_setting('limit', 'thewire');
-
-if(strlen($message) > $char_limit) {
-	register_error(elgg_echo('missions:error:wire_post_too_long'));
-	forward(REFERER);
-}
-else {
-	thewire_tools_save_post($message, elgg_get_logged_in_user_guid(), ACCESS_LOGGED_IN);
-	
-	system_message(elgg_echo('missions:posted_to_the_wire'));
-	forward(elgg_get_site_url() . 'missions/main');
-}
-Nick - Replacing the old share on the wire tools action
-*/
+//Nick - Replaced the old action with the wire reshare action from wire_tools
 
 $body = get_input("body", "", false);
 

--- a/mod/missions/pages/missions/message-share.php
+++ b/mod/missions/pages/missions/message-share.php
@@ -29,10 +29,7 @@ switch($switch_segment) {
 		}
 		else if($entity->type == 'object' && get_subtype_from_id($entity->subtype) == 'mission') {
 
-            //Nick changing this to use the wire reshare view
-            /*$main_content = elgg_view('thewire_tools/reshare', array(
-                "reshare_guid"=>$entity_guid,
-                ));*/
+            //Nick changing this to use the wire reshare view and added col class
 			$main_content = elgg_view_form('missions/wire-post', array('class'=>'clearfix col-sm-8',), array('entity_subject' => $entity)) . '</section>';
 			$title = elgg_echo('missions:share_with_colleague');
 		}

--- a/mod/missions/pages/missions/message-share.php
+++ b/mod/missions/pages/missions/message-share.php
@@ -28,7 +28,12 @@ switch($switch_segment) {
 			// Not in use at the moment.
 		}
 		else if($entity->type == 'object' && get_subtype_from_id($entity->subtype) == 'mission') {
-			$main_content = elgg_view_form('missions/wire-post', array(), array('entity_subject' => $entity)) . '</section>';
+
+            //Nick changing this to use the wire reshare view
+            /*$main_content = elgg_view('thewire_tools/reshare', array(
+                "reshare_guid"=>$entity_guid,
+                ));*/
+			$main_content = elgg_view_form('missions/wire-post', array('class'=>'clearfix col-sm-8',), array('entity_subject' => $entity)) . '</section>';
 			$title = elgg_echo('missions:share_with_colleague');
 		}
 		$highlight_two = true;

--- a/mod/missions/views/default/forms/missions/wire-post.php
+++ b/mod/missions/views/default/forms/missions/wire-post.php
@@ -10,36 +10,129 @@
 /*
  * Form which allows users to post a message to The Wire about the subject mission entity.
  */
-$entity = $vars['entity_subject'];
 
-$char_limit = (int)elgg_get_plugin_setting('limit', 'thewire');
-$rows = 2;
-if($char_limit > 140) {
-	$row = 3;
+//Nick - cutting up the orginal share on wire form
+
+/**
+ * Wire add form body
+ *
+ * @uses $vars["post"]
+ */
+
+elgg_load_js("elgg.thewire");
+
+$post = elgg_extract("post", $vars);
+$char_limit = thewire_tools_get_wire_length();
+//Changes to entity_subject
+$reshare = elgg_extract("entity_subject", $vars); // for reshare functionality
+
+$text = elgg_echo("post");
+if ($post) {
+	$text = elgg_echo("reply");
+}
+$chars_left = elgg_echo("thewire:charleft");
+
+$parent_input = "";
+if ($post) {
+	$parent_input = elgg_view("input/hidden", array(
+		"name" => "parent_guid",
+		"value" => $post->guid,
+	));
 }
 
-$input_message = elgg_view('input/plaintext', array(
-		'name' => 'wire_message',
-		'value' => elgg_echo('missions:check_this_mission', array(elgg_get_excerpt($entity->job_title, elgg_get_plugin_setting('mission_job_title_card_cutoff', 'missions')/2), $entity->getURL())),
-		'id' => 'mission-message-share-wire-message-text-input',
-		'class' => 'mtm thewire-textarea form-control elgg-input-plaintext',
-		'data-max-length' => $char_limit,
-		'rows' => $rows
-));
-?>
+$reshare_input = "";
+$post_value = "";
+if (!empty($reshare)) {
+	$reshare_input = elgg_view("input/hidden", array(
+		"name" => "reshare_guid",
+		"value" => $reshare->getGUID()
+	));
 
-<div class="col-sm-8">
-	<label for="mission-message-share-wire-message-text-input"><?php elgg_echo('missions:create_wire_post'); ?></label>
-	<?php echo $input_message; ?>
+	$reshare_input .= elgg_view("thewire_tools/reshare_source", array("entity" => $reshare));
+
+	if (!empty($reshare->title)) {
+		$post_value = $reshare->title;
+	} elseif (!empty($reshare->name)) {
+		$post_value = $reshare->name;
+	} elseif (!empty($reshare->description)) {
+		$post_value = elgg_get_excerpt($reshare->description, 140);
+	}
+}
+
+$count_down = "<span>$char_limit</span> $chars_left";
+$num_lines = 2;
+if ($char_limit == 0) {
+	$num_lines = 3;
+	$count_down = "";
+} else if ($char_limit > 140) {
+	$num_lines = 3;
+}
+
+$post_input = elgg_view("input/plaintext", array(
+	"name" => "body",
+	"class" => "mtm thewire-textarea",
+	"rows" => $num_lines,
+	"value" => $post_value,
+	"data-max-length" => $char_limit,
+));
+
+$submit_button = elgg_view("input/submit", array(
+	"value" => $text,
+	"class" => "elgg-button elgg-button-submit thewire-submit-button",
+));
+
+$mentions = "";
+$access_input = "";
+if (thewire_tools_groups_enabled()) {
+
+	if ($post) {
+		$access_input = elgg_view("input/hidden", array("name" => "access_id", "value" => $post->access_id));
+	} else {
+		$page_owner_entity = elgg_get_page_owner_entity();
+
+		if ($page_owner_entity instanceof ElggGroup) {
+			// in a group only allow sharing in the current group
+			$access_input = elgg_view("input/hidden", array("name" => "access_id", "value" => $page_owner_entity->group_acl));
+			$mentions = "<div class='elgg-subtext mbn'>" . elgg_echo("thewire_tools:groups:mentions") . "</div>";
+		} else {
+			$params = array(
+				"name" => "access_id"
+			);
+
+			if (elgg_in_context("widgets")) {
+				$params["class"] = "thewire-tools-widget-access";
+			}
+
+			elgg_push_context("thewire_add");
+			$access_input = elgg_view("input/access", $params);
+			elgg_pop_context();
+		}
+	}
+}
+
+echo <<<HTML
+	$reshare_input
+	$post_input
+<div class="thewire-characters-remaining">
+	$count_down
 </div>
-<div class="col-sm-8"> 
-	<?php
-		echo elgg_view('input/submit', array(
-				'value' => elgg_echo('missions:post'),
-				'class' => 'elgg-button btn btn-primary',
-				'style' => 'float:right;',
-				'id' => 'mission-message-share-wire-post-submission-button'
-		)); 
-		echo elgg_view('page/elements/one-click-restrictor', array('restricted_element_id' => 'mission-message-share-wire-post-submission-button'));
-	?> 
+$mentions
+<div class="elgg-foot mts">
+	$parent_input
+	$submit_button
+	$access_input
 </div>
+HTML;
+
+if (elgg_is_xhr()) {
+?>
+<script type="text/javascript">
+		$("#thewire-tools-reshare-wrapper").find('.elgg-form-thewire-add textarea[name="body"]').each(function(i) {
+			elgg.thewire_tools.init_autocomplete(this);
+		});
+</script>
+<?php
+}
+
+
+?>

--- a/mod/missions/views/default/forms/missions/wire-post.php
+++ b/mod/missions/views/default/forms/missions/wire-post.php
@@ -11,8 +11,8 @@
  * Form which allows users to post a message to The Wire about the subject mission entity.
  */
 
-//Nick - cutting up the orginal share on wire form
-
+//Nick - cutting up the orginal share on wire form to keep consistancy on the site
+//Cleaned up some of this file as it will only deal with mission opportunities
 /**
  * Wire add form body
  *
@@ -23,7 +23,7 @@ elgg_load_js("elgg.thewire");
 
 $post = elgg_extract("post", $vars);
 $char_limit = thewire_tools_get_wire_length();
-//Changes to entity_subject
+//Changed to entity_subject as this what was already passed to this view
 $reshare = elgg_extract("entity_subject", $vars); // for reshare functionality
 
 $text = elgg_echo("post");
@@ -83,32 +83,7 @@ $submit_button = elgg_view("input/submit", array(
 
 $mentions = "";
 $access_input = "";
-if (thewire_tools_groups_enabled()) {
 
-	if ($post) {
-		$access_input = elgg_view("input/hidden", array("name" => "access_id", "value" => $post->access_id));
-	} else {
-		$page_owner_entity = elgg_get_page_owner_entity();
-
-		if ($page_owner_entity instanceof ElggGroup) {
-			// in a group only allow sharing in the current group
-			$access_input = elgg_view("input/hidden", array("name" => "access_id", "value" => $page_owner_entity->group_acl));
-			$mentions = "<div class='elgg-subtext mbn'>" . elgg_echo("thewire_tools:groups:mentions") . "</div>";
-		} else {
-			$params = array(
-				"name" => "access_id"
-			);
-
-			if (elgg_in_context("widgets")) {
-				$params["class"] = "thewire-tools-widget-access";
-			}
-
-			elgg_push_context("thewire_add");
-			$access_input = elgg_view("input/access", $params);
-			elgg_pop_context();
-		}
-	}
-}
 
 echo <<<HTML
 	$reshare_input


### PR DESCRIPTION
There is a JIRA ticket about sharing mission opportunities on the wire. I have modified the mission share to the wire forms and actions to match that of the wire reshare functions seen throughout the site.

@Phanoix can you take a quick look and test if you can share a mission on the wire and it looks and functions like other objects shared on the wire. Thx