### PR TITLE
Suggested colleagues bug quick fix

### DIFF
--- a/mod/wet4/views/default/river/elements/layout.php
+++ b/mod/wet4/views/default/river/elements/layout.php
@@ -29,27 +29,29 @@ if(intval($_SESSION['Suggested_friends'])==5 && elgg_is_logged_in())
             $htmloutput=$htmloutput.'<h4 class="h4 mrgn-tp-0 text-primary">'.elgg_echo('sf:title').'</h3>';
             while ($row = $result->fetch_assoc()) {
                  $userGUID=$row['guid_two'];
-                $job=get_user($userGUID)->job;
-                $user_department=get_user($userGUID)->department;
-                $htmloutput=$htmloutput.'<div class="col-xs-4 text-center hght-inhrt">'; // suggested friend link to profile
-                $htmloutput .= '<a href="'.  $site_url. 'profile/'. get_user($row['guid_two'])->username.'" class="">';
+		if (elgg_get_user_validation_status($userGUID)){
+                	$job=get_user($userGUID)->job;
+                	$user_department=get_user($userGUID)->department;
+                	$htmloutput=$htmloutput.'<div class="col-xs-4 text-center hght-inhrt">'; // suggested friend link to profile
+                	$htmloutput .= '<a href="'.  $site_url. 'profile/'. get_user($row['guid_two'])->username.'" class="">';
 
-                //EW - change to render icon so new ambassador badges can be shown
-                $htmloutput.= elgg_view_entity_icon(get_entity($userGUID), 'medium', array('use_hover' => false, 'use_link' => false, 'class' => 'elgg-avatar-wet4-sf'));
-                //$htmloutput=$htmloutput.'<img src="'.get_user($row['guid_two'])->getIcon('medium') . '" class="avatar-profile-page img-responsive center-block img-circle elgg-avatar-wet4-sf" alt="'.elgg_echo('sf:alttext').' '.get_user($row['guid_two'])->getDisplayName().'">';
-                $htmloutput=$htmloutput.'<h4 class="h4 mrgn-tp-sm"><span class="text-primary">'.get_user($row['guid_two'])->getDisplayName().'</span></h4></a>';
-                if($job){ // Nick - Adding department if no job, if none add a space
-                    $htmloutput=$htmloutput.'<p class="small mrgn-tp-0">'.$job.'</p>';
-                }elseif(!$job && $user_department){
-                    $htmloutput=$htmloutput.'<p class="small mrgn-tp-0">'.$user_department.'</p>';
-                }else{
-                    $htmloutput=$htmloutput.'<p class="small mrgn-tp-0 min-height-cs"></p>';
-                }
+                	//EW - change to render icon so new ambassador badges can be shown
+                	$htmloutput.= elgg_view_entity_icon(get_entity($userGUID), 'medium', array('use_hover' => false, 'use_link' => false, 'class' => 'elgg-avatar-wet4-sf'));
+                	//$htmloutput=$htmloutput.'<img src="'.get_user($row['guid_two'])->getIcon('medium') . '" class="avatar-profile-page img-responsive center-block img-circle elgg-avatar-wet4-sf" alt="'.elgg_echo('sf:alttext').' '.get_user($row['guid_two'])->getDisplayName().'">';
+                	$htmloutput=$htmloutput.'<h4 class="h4 mrgn-tp-sm"><span class="text-primary">'.get_user($row['guid_two'])->getDisplayName().'</span></h4></a>';
+                	if($job){ // Nick - Adding department if no job, if none add a space
+                	    $htmloutput=$htmloutput.'<p class="small mrgn-tp-0">'.$job.'</p>';
+                	}elseif(!$job && $user_department){
+                	    $htmloutput=$htmloutput.'<p class="small mrgn-tp-0">'.$user_department.'</p>';
+                	}else{
+                	    $htmloutput=$htmloutput.'<p class="small mrgn-tp-0 min-height-cs"></p>';
+                	}
                
-                //changed connect button to send a friend request we should change the wording
-                $htmloutput=$htmloutput.'<a href="'.elgg_add_action_tokens_to_url("action/friends/add?friend={$userGUID}"). '" class="btn btn-primary mrgn-tp-sm">'.elgg_echo('friend:add').'</a>';
-                $htmloutput=$htmloutput.'</div>';
-               // $htmloutput=$htmloutput. $row['guid_two'].'-';
+                	//changed connect button to send a friend request we should change the wording
+                	$htmloutput=$htmloutput.'<a href="'.elgg_add_action_tokens_to_url("action/friends/add?friend={$userGUID}"). '" class="btn btn-primary mrgn-tp-sm">'.elgg_echo('friend:add').'</a>';
+                	$htmloutput=$htmloutput.'</div>';
+               		// $htmloutput=$htmloutput. $row['guid_two'].'-';
+	       }
             }
             $htmloutput=$htmloutput.'</div>';
             $htmloutput=$htmloutput.'<div class="clearfix"></div>';

--- a/mod/wet4/views/default/widgets/suggested_friends/content.php
+++ b/mod/wet4/views/default/widgets/suggested_friends/content.php
@@ -37,21 +37,23 @@ try{
                     $htmloutput=$htmloutput.'<div class="row mrgn-tp-sm">';
                 }
                 $userGUID=$row['guid_two'];
-                $job=get_user($userGUID)->job;
-                $htmloutput=$htmloutput.'<div class="col-xs-6 text-center">';
-                $htmloutput .= '<a href="'.  $site_url. 'profile/'. get_user($row['guid_two'])->username.'" class="">';
-                $htmloutput=$htmloutput.'<img src="'.get_user($row['guid_two'])->getIcon('small') . '" class="avatar-profile-page img-responsive center-block img-circle " alt="'.elgg_echo('sf:alttext').' '.get_user($row['guid_two'])->getDisplayName().'">';
-                $htmloutput=$htmloutput.'<h4 class="h4 mrgn-tp-sm mrgn-bttm-0"><span class="text-primary">'.get_user($row['guid_two'])->getDisplayName().'</span></h4></a>';
-                $htmloutput=$htmloutput.'<p class="small mrgn-tp-0">'.$job.'</p>';
-                $htmloutput=$htmloutput.'<a href="'.elgg_add_action_tokens_to_url("action/friends/add?friend={$userGUID}"). '" class="btn btn-primary btn-sm mrgn-tp-sm">'.elgg_echo('friend:add').'</a>';
-                $htmloutput=$htmloutput.'</div>';
-                if($count==1 || $count==3)
-                {
-                    $htmloutput=$htmloutput.'</div>';
-                }
-                $count++;
-               // $htmloutput=$htmloutput. $row['guid_two'].'-';
-            }
+		if (elgg_get_user_validation_status($userGUID)){
+                	$job=get_user($userGUID)->job;
+                	$htmloutput=$htmloutput.'<div class="col-xs-6 text-center">';
+                	$htmloutput .= '<a href="'.  $site_url. 'profile/'. get_user($row['guid_two'])->username.'" class="">';
+                	$htmloutput=$htmloutput.'<img src="'.get_user($row['guid_two'])->getIcon('small') . '" class="avatar-profile-page img-responsive center-block img-circle " alt="'.elgg_echo('sf:alttext').' '.get_user($row['guid_two'])->getDisplayName().'">';
+                	$htmloutput=$htmloutput.'<h4 class="h4 mrgn-tp-sm mrgn-bttm-0"><span class="text-primary">'.get_user($row['guid_two'])->getDisplayName().'</span></h4></a>';
+                	$htmloutput=$htmloutput.'<p class="small mrgn-tp-0">'.$job.'</p>';
+                	$htmloutput=$htmloutput.'<a href="'.elgg_add_action_tokens_to_url("action/friends/add?friend={$userGUID}"). '" class="btn btn-primary btn-sm mrgn-tp-sm">'.elgg_echo('friend:add').'</a>';
+                	$htmloutput=$htmloutput.'</div>';
+                	if($count==1 || $count==3)
+                	{
+                	    $htmloutput=$htmloutput.'</div>';
+                	}
+                	$count++;
+               		// $htmloutput=$htmloutput. $row['guid_two'].'-';
+            	}
+	    }
             $htmloutput=$htmloutput.'</div></div>';
             $htmloutput=$htmloutput.'<div class="clearfix"></div>';
             //$htmloutput=$htmloutput.'</div>';


### PR DESCRIPTION
Will no longer crash when trying to show unvalidated users - it will now simply skip them. The feature is set to be rewritten and will handle these cases more elegantly at a later time.