### PR TITLE
Missions_organization fix for pre-filling department field in opportunity creation

### DIFF
--- a/mod/missions/views/default/forms/missions/post-mission-first-form.php
+++ b/mod/missions/views/default/forms/missions/post-mission-first-form.php
@@ -35,7 +35,7 @@ if(!elgg_is_sticky_form('firstfill')) {
 	if(!$extracted_org) {
 		$exploded_department = explode('/', $user->department);
 		$department_name = trim($exploded_department[0]);
-		$extracted_org = false;//mo_format_input_node(mo_get_department_next_to_root($department_name));
+		$extracted_org = mo_format_input_node(mo_get_department_next_to_root($department_name));
 	}
 	if(!$email) {
 		$email = $user->email;

--- a/mod/missions_organization/lib/missions-organization.php
+++ b/mod/missions_organization/lib/missions-organization.php
@@ -230,13 +230,13 @@ function mo_get_department_next_to_root($name) {
 	$options['type'] = 'object';
 	$options['subtype'] = 'orgnode';
 	$options['metadata_name_value_pairs'] = array(
-			array('name' => 'parent_guid', 'value' => mo_get_tree_root()->guid, 'operand' => '='),
+			//array('name' => 'parent_guid', 'value' => mo_get_tree_root()->guid, 'operand' => '='),
 			array('name' => 'name', 'value' => $name, 'operand' => '=', 'case_sensitive' => false)
 	);
 	$entities = elgg_get_entities_from_metadata($options);
 	
 	if(count($entities) == 1) {
-		return $entities[0];
+		return $entities[0]->guid;
 	}
 	else {
 		return false;


### PR DESCRIPTION
addresses issue #461  
This functionality was disabled before due to it not working properly and defaulting the department drop-downs to less than useful values, which combined with and IE bug prevented users from easily filling out the form. With this fix it should hopefully work as intended.

@piet0024 could you quickly look over this? It ended up only being a few lines
@LemieuxGen This is probably notable enough to require some level of communication