### PR TITLE
fixed malformed javascript

### DIFF
--- a/mod/b_extended_profile/js/endorsements/gcconnex-profile.js
+++ b/mod/b_extended_profile/js/endorsements/gcconnex-profile.js
@@ -590,12 +590,7 @@ function saveProfile(event) {
                         if ($(this).data('guid') != "new") {
                             $delete_guid.push($(this).data('guid'));
                         }
-                    }
-                }else {
-                    $education_guid.push($(this).data('guid'));
-                }
-            });
-                    else {
+                    } else {
                         $education_guid.push($(this).data('guid'));
                     }
                 });
@@ -860,7 +855,6 @@ function saveProfile(event) {
                             }
                         });
 
-            break;
                         //title field
                         if($.trim(experience['title']) == ''){
                           $(this).find('.gcconnex-work-experience-title').addClass('input-error').attr('aria-invalid', "true");
@@ -1344,7 +1338,6 @@ function deleteEntry(identifier) {
         $('.cancel-' + entryType).focus();
 
     } 
-    }
 }
 
 /*


### PR DESCRIPTION
While testing the application locally; I was unable to add skills to my profile (or any other dynamic field) ... Turns out the problem was with malformed javascript.

I was testing using Chrome 53 - I also tested using IE 11.