### PR TITLE
adding wb-tables, table-striped, table-hover classes

### DIFF
--- a/mod/htmlawed/start.php
+++ b/mod/htmlawed/start.php
@@ -110,7 +110,7 @@ function htmlawed_tag_post_processor($element, $attributes = false) {
 	);
 
 	$allowed_classes = array(
-		'table', 'row' 
+		'table', 'row', 'wb-tables', 'table-striped', 'table-hover'
 	);
 
 	$params = array('tag' => $element);


### PR DESCRIPTION
Adding wb-tables, table-striped, table-hover css classes to a white-list for the sanitizer
This allows users to add these css classes to their tables in blogs, comments, etc.
closes #365 