### PR TITLE
Fixed users not being able to open pdf files in-browser

### DIFF
--- a/mod/file/pages/file/download.php
+++ b/mod/file/pages/file/download.php
@@ -29,7 +29,7 @@ header("Content-type: $mime");
 if (strpos($mime, "image/") !== false || $mime == "application/pdf") {
 	header("Content-Disposition: inline; filename=\"$filename\"");
 } else {
-	header("Content-Disposition: inline; filename=\"$filename\"");
+	header("Content-Disposition: attachment; filename=\"$filename\"");
 }
 header("Content-Length: {$file->getSize()}");
 

--- a/mod/file/pages/file/download.php
+++ b/mod/file/pages/file/download.php
@@ -26,7 +26,11 @@ $filename = $file->originalfilename;
 header("Pragma: public");
 
 header("Content-type: $mime");
-header("Content-Disposition: attachment; filename=\"$filename\"");
+if (strpos($mime, "image/") !== false || $mime == "application/pdf") {
+	header("Content-Disposition: inline; filename=\"$filename\"");
+} else {
+	header("Content-Disposition: inline; filename=\"$filename\"");
+}
 header("Content-Length: {$file->getSize()}");
 
 while (ob_get_level()) {


### PR DESCRIPTION
Update to elgg1.12 broke image and pdf files being able to open in-browser, this fixes it.
fixes #527 

@LemieuxGen This seems to be something that's been complained about several times, and we have a fix for it now.