### PR TITLE
Recreating old css views used to overwrite core views

### DIFF
--- a/mod/wet4/views/default/css/elements/components.php
+++ b/mod/wet4/views/default/css/elements/components.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Layout Object CSS
+ *
+ * Image blocks, lists, tables, gallery, messages
+ *
+ * @package Elgg.Core
+ * @subpackage UI
+ *
+ * GC_MODIFICATION
+ * Description: This file exists to overwrite the core image block and component styles
+ * Author: Nick github.com/piet0024
+ */
+?>
+/* <style> /**/
+/* ***************************************
+	Image Block
+*************************************** */
+/******* Custom CSS for messages *********/

--- a/mod/wet4/views/default/css/elements/navigation.php
+++ b/mod/wet4/views/default/css/elements/navigation.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * navigation.php
+ * 
+ * This file exisits to overwrite core navigation styles
+ * 
+ * @package wet4
+ * @author Nick github.com/piet0024
+ */
+
+?>
+
+/* <style> /**/
+ 
+ /* ***************************************
+ 	PAGINATION
+ *************************************** */
+ 

--- a/mod/wet4/views/default/css/elements/typography.php
+++ b/mod/wet4/views/default/css/elements/typography.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * CSS typography
+ *
+ * @package Elgg.Core
+ * @subpackage UI
+ *
+ * GC_MODIFICATION
+ * Description: This file overwrites the core typography styling
+ * Author: Nick github.com/piet0024
+ */
+?>
+/* <style> /**/
+/* ***************************************
+	Typography
+*************************************** */
+/* ***************************************
+	USER INPUT DISPLAY RESET
+*************************************** */


### PR DESCRIPTION
While commenting out and cleaning up files in wet, we removed some css files that override core styles. This caused strange layout issue. Adding those override files back.