### PR TITLE
Updated blank labels to "Other"

### DIFF
--- a/mod/missions/lib/missions-analytics.php
+++ b/mod/missions/lib/missions-analytics.php
@@ -444,15 +444,19 @@ function mm_analytics_generate_separation_labels($separator) {
 			break;
 		case 'missions:type':
 			$returner = explode(',', elgg_get_plugin_setting('opportunity_type_string', 'missions'));
+			$returner[0] = 'missions:other';
 			break;
 		case 'missions:reason_to_decline':
 			$returner = explode(',', elgg_get_plugin_setting('decline_reason_string', 'missions'));
+			$returner[0] = 'missions:other';
 			break;
 		case 'missions:location':
 			$returner = explode(',', elgg_get_plugin_setting('province_string', 'missions'));
+			$returner[0] = 'missions:other';
 			break;
 		case 'missions:field_of_work':
 			$returner = explode(',', elgg_get_plugin_setting('program_area_string', 'missions'));
+			$returner[0] = 'missions:other';
 			break;
 		default:
 			$returner = array('missions:all_opportunities');


### PR DESCRIPTION
Stack graph will now use the label "Other" instead of an empty string when separated by:
1. Program Area
1. Opportunity Type
1. Reason to decline
1. Location

fixes #500