### PR TITLE
Federated Search update

### DIFF
--- a/mod/gc_fedsearch_gsa/start.php
+++ b/mod/gc_fedsearch_gsa/start.php
@@ -10,6 +10,7 @@ function gc_fedsearch_gsa_init() {
 	$gsa_pagination = elgg_get_plugin_setting('gsa_pagination','gc_fedsearch_gsa');
 	if ($gsa_pagination) elgg_extend_view('css/elgg', 'css/intranet_results_pagination', 1);
 	
+	elgg_extend_view('page/elements/head', 'page/elements/head_gsa', 1);  
 }
 
 function group_url($hook, $type, $return, $params) {

--- a/mod/gc_fedsearch_gsa/start.php
+++ b/mod/gc_fedsearch_gsa/start.php
@@ -71,7 +71,7 @@ function entity_url($hook, $type, $return, $params) {
  
 		// zube issue 533 (invalid url, appends to end of current URL)
 		$url = explode('/',$_SERVER['REQUEST_URI']);
-		$entity = get_entity($url[4]);
+		$entity = get_entity($url[3]);
 
 		// description is determined by the language that has been currently set
 		$current_language = get_current_language();

--- a/mod/gc_fedsearch_gsa/start.php
+++ b/mod/gc_fedsearch_gsa/start.php
@@ -31,7 +31,7 @@ function entity_url($hook, $type, $return, $params) {
 	if ($gsa_usertest) $current_user = elgg_get_logged_in_user_entity();
 
 	// do this only for the gsa-crawler (and usertest is empty)
-	if ((!$gsa_usertest) && strcmp($gsa_agentstring,strtolower($_SERVER['HTTP_USER_AGENT'])) == 0)  {
+	if ( ((!$gsa_usertest) && strcmp($gsa_agentstring,strtolower($_SERVER['HTTP_USER_AGENT'])) == 0) || strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'gsa-crawler') !== false )  {
 
 		/*blog pages bookmarks file discussion*/
 		$filter_entity = array('blog', 'pages', 'discussion', 'file', 'bookmarks');
@@ -66,6 +66,40 @@ function entity_url($hook, $type, $return, $params) {
 			}
 			$return .= $description->textContent;	
 		}
+
+	} else {
+ 
+		// zube issue 533 (invalid url, appends to end of current URL)
+		$url = explode('/',$_SERVER['REQUEST_URI']);
+		$entity = get_entity($url[4]);
+
+		// description is determined by the language that has been currently set
+		$current_language = get_current_language();
+		if(!$current_language) $current_language = 'en';
+
+		$description = new DOMDocument();
+		(strcmp($current_language,'en') == 0) ? $description->loadHTML($entity->description) : $description->loadHTML($entity->description2);
+
+		$links = $description->getElementsByTagName('a');
+		for ($i = $links->length - 1; $i >= 0; $i--) {
+			$linkNode = $links->item($i);
+			$lnkText = $linkNode->getAttribute('href');
+
+			// if http(s):// is not present, append it
+			$url = parse_url($lnkText);
+			if (empty($url['scheme'])) {
+				$lnkText = $linkNode->setAttribute('href', "http://{$lnkText}");
+			}
+			
+			// remove and replace non-ascii characters
+			$lnkText = preg_replace('/[^(\x20-\x7F)]*/','', $lnkText);
+			$lnkText = $linkNode->setAttribute('href', $lnkText);
+
+			// remove and replace blocked:: (for users who copy paste from Outlook)
+
+		}
+
+		$return = $description->saveHTML();
 	}
    
 	return $return;

--- a/mod/gc_fedsearch_gsa/start.php
+++ b/mod/gc_fedsearch_gsa/start.php
@@ -80,6 +80,7 @@ function entity_url($hook, $type, $return, $params) {
 		$description = new DOMDocument();
 		(strcmp($current_language,'en') == 0) ? $description->loadHTML($entity->description) : $description->loadHTML($entity->description2);
 
+		// for all the links <a href= ... />
 		$links = $description->getElementsByTagName('a');
 		for ($i = $links->length - 1; $i >= 0; $i--) {
 			$linkNode = $links->item($i);
@@ -96,7 +97,19 @@ function entity_url($hook, $type, $return, $params) {
 			$lnkText = $linkNode->setAttribute('href', $lnkText);
 
 			// remove and replace blocked:: (for users who copy paste from Outlook)
+			$lnkText = str_replace("blocked::", "", $lnkText);
+		}
 
+
+		// for all the links <em title= ... />
+		$links = $description->getElementsByTagName('em');
+		for ($i = $links->length - 1; $i >= 0; $i--) {
+			$linkNode = $links->item($i);
+			$lnkText = $linkNode->getAttribute('title');
+
+			// remove and replace blocked:: (for users who copy paste from Outlook)
+			$lnkText = preg_replace('/^blocked::/','', $lnkText);
+			$lnkText = $linkNode->setAttribute('title', $lnkText);
 		}
 
 		$return = $description->saveHTML();

--- a/mod/gc_fedsearch_gsa/views/default/output/tag.php
+++ b/mod/gc_fedsearch_gsa/views/default/output/tag.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Elgg single tag output. Accepts all output/url options
+ *
+ * @uses $vars['value']    String
+ * @uses $vars['type']     The entity type, optional
+ * @uses $vars['subtype']  The entity subtype, optional
+ * @uses $vars['base_url'] Base URL for tag link, optional, defaults to search URL
+ *
+ * GC MODIFICATION
+ *	christine yu 	redirects core functionality to GSA search interface (views/default/output/tags.php)
+ */
+
+if (empty($vars['value']) && $vars['value'] !== 0 && $vars['value'] !== '0') {
+	return;
+}
+ 
+$gsa_tags_key = elgg_get_plugin_setting('gsa_param_key','gc_fedsearch_gsa');
+$gsa_tags_value = elgg_get_plugin_setting('gsa_param_value','gc_fedsearch_gsa');
+
+$query_params = array();
+$query_params["q"] = $vars['value'];
+$query_params["search_type"] = "tags";
+$query_params["a"] = "s";
+$query_params["s"] = "3";
+
+if ($gsa_tags_key && $gsa_tags_value)
+	$query_params[$gsa_tags_key] = $gsa_tags_value;
+
+$current_language = get_current_language();
+$gsa_language = (strcmp($current_language,'en') == 0) ? 'eng' : 'fra';
+$url = "http://intranet.canada.ca/search-recherche/query-recherche-{$gsa_language}.aspx?".http_build_query($query_params); 
+
+$params = array(
+	'href' => $url,
+	'text' => $vars['value'],
+	'encode_text' => true,
+	'rel' => 'tag',
+);
+
+$params = $params + $vars;
+
+echo elgg_view('output/url', $params);

--- a/mod/gc_fedsearch_gsa/views/default/page/elements/head_gsa.php
+++ b/mod/gc_fedsearch_gsa/views/default/page/elements/head_gsa.php
@@ -1,0 +1,7 @@
+<?php
+
+	global $my_page_entity;
+
+?>
+  
+ <meta name='keywords' content="<?php echo implode(',',$my_page_entity->tags); ?>" />;

--- a/mod/gc_fedsearch_gsa/views/default/plugins/gc_fedsearch_gsa/settings.php
+++ b/mod/gc_fedsearch_gsa/views/default/plugins/gc_fedsearch_gsa/settings.php
@@ -3,15 +3,24 @@
 $gsa_agentstring = $vars['entity']->gsa_agentstring;
 if (!$gsa_agentstring) { $vars['entity']->gsa_agentstring = 'gsa-crawler'; }	
 
+// agent string of the crawler
 $gsa_user_agentstring_label = "<label>Federated Search GSA Agent-String</label>";
 $gsa_user_agentstring = elgg_view('input/text', array(
 	'name' => 'params[gsa_agentstring]',
 	'value' => $vars['entity']->gsa_agentstring));
 
+// parameters that needs to be passed in and redirect to intranet result page
+$gsa_param_keyvalue_label = "<label>Parameters for the GSA federated search page (Parameter name and Parameter value)</label>";
+$gsa_param_key = elgg_view('input/text', array(
+	'name' => 'params[gsa_param_key]',
+	'value' => $vars['entity']->gsa_param_key));
+$gsa_param_value = elgg_view('input/text', array(
+	'name' => 'params[gsa_param_value]',
+	'value' => $vars['entity']->gsa_param_value));
 
 // for testing purposes 
 $gsa_user_test_label = "<label>Username to be tested (please leave empty in production)</label>";
-$gsa_user_test = elgg_view('input/text', array(
+$gsa_user_test = elgg_view('input/text', array( 
 	'name' => 'params[gsa_test]',
 	'value' => $vars['entity']->gsa_test));
 
@@ -26,5 +35,7 @@ $gsa_results_pagination = elgg_view('input/text', array(
 // display to page
 echo "<br/><br/>";
 echo "<p>{$gsa_user_agentstring_label}{$gsa_user_agentstring}</p>";
+echo "<p>{$gsa_param_keyvalue_label}{$gsa_param_key}{$gsa_param_value}</p>";
 echo "<p>{$gsa_user_test_label}{$gsa_user_test}</p>";
-echo "<p>{$gsa_results_pagination_label}{$gsa_results_pagination}</p>";
+echo "<p>{$gsa_results_pagination_label}{$gsa_results_pagination}</p>"; 
+ 


### PR DESCRIPTION
The tags are now implemented as Metadata, GSA should now be able to pick that up and users should be able to do seach by tags (via tags in content) using the GSA. 
Those unusual hyperlinks have been corrected (display only) but content is not updated, this usually affects older data)