### PR TITLE
Related groups dropdown now scrolls

### DIFF
--- a/mod/gc_group_layout/views/default/group/default.php
+++ b/mod/gc_group_layout/views/default/group/default.php
@@ -1,7 +1,7 @@
-<?php 
+<?php
 /**
  * Group entity view
- * 
+ *
  * @package ElggGroups
  */
 
@@ -30,7 +30,7 @@ if (elgg_in_context('owner_block') || elgg_in_context('widgets')) {
 
 if ($vars['full_view']) {
 	echo elgg_view('groups/profile/summary', $vars);
-} else {
+} else if(!elgg_in_context('livesearch')){
 	// brief view
 	$params = array(
 		'entity' => $group,
@@ -52,8 +52,8 @@ if($group->briefdescription3){
 
 	// identify available content
 /*if(($group->description2) && ($group->description)){
-		
-			echo'<span class="col-md-1 col-md-offset-11"><i class="fa fa-language fa-lg mrgn-rght-sm"></i>' . '<span class="wb-inv">Content available in both language</span></span>';	
+
+			echo'<span class="col-md-1 col-md-offset-11"><i class="fa fa-language fa-lg mrgn-rght-sm"></i>' . '<span class="wb-inv">Content available in both language</span></span>';
 }*/
 
 	$params = $params + $params2;
@@ -61,4 +61,9 @@ if($group->briefdescription3){
 	$list_body = elgg_view('group/elements/summary', $params);
 
 	echo elgg_view_image_block($icon, $list_body, $vars);
+} else {
+  $icon = elgg_view_entity_icon($group, 'medium', $vars);
+  $body = $group->name;
+
+  echo elgg_view_image_block($icon, $body, $vars);
 }

--- a/mod/wet4/views/default/wet4_theme/custom_css.php
+++ b/mod/wet4/views/default/wet4_theme/custom_css.php
@@ -1652,8 +1652,23 @@ figcaption{
     text-decoration: underline;
     cursor: pointer;
 }
-  
+
 .indicator_summary{
   color:#D6D6D6;
   font-size: 12px
+}
+
+/*Related groups autocomplete*/
+.ui-autocomplete .ui-menu-item {
+  clear:both;
+  overflow:auto;
+}
+.ui-autocomplete .ui-menu-item:hover {
+  background:#eee;
+}
+.ui-autocomplete .ui-menu-item:focus {
+  background:#eee;
+}
+.ui-state-hover, .ui-widget-content .ui-state-hover, .ui-widget-header .ui-state-hover, .ui-state-focus, .ui-widget-content .ui-state-focus, .ui-widget-header .ui-state-focus {
+  border:none;
 }


### PR DESCRIPTION
Dropdown will now scroll properly through the list of search results.
Changed styling of search results to display more groups and avoid
travelling to the group when the user clicks the group they want.

Fixes #638 