### PR TITLE
Added personalized message and name of sender to invite colleagues - Fixes #559

### DIFF
--- a/mod/cp_notifications/languages/en.php
+++ b/mod/cp_notifications/languages/en.php
@@ -179,7 +179,7 @@ $english = array(
 
 	// invited to join GCconnex section
 	'cp_notify:subject:invite_new_user' => "You have been invited to join GCconnex",
-	'cp_notify:body_invite_new_user:title' => "You have been invited to join GCconnex",
+	'cp_notify:body_invite_new_user:title' => "You have been invited to join GCconnex by %s",
 	'cp_notify:body_invite_new_user:description' => "Join the professionnal networking and collaborative workspace for all public service. You can proceed to your GCconnex registration through this link %s", 
 
 

--- a/mod/cp_notifications/languages/fr.php
+++ b/mod/cp_notifications/languages/fr.php
@@ -208,7 +208,7 @@ $french = array(
 
 	// invite new user to GCconnex
 	'cp_notify:subject:invite_new_user' => "Vous avez été invité à joindre GCconnex",
-	'cp_notify:body_invite_new_user:title' => "Vous avez été invité à joindre GCconnex",
+	'cp_notify:body_invite_new_user:title' => "Vous avez été invité à joindre GCconnex par %s",
 	'cp_notify:body_invite_new_user:description' => "Joignez-vous à l'espace de travail collaboratif pour le réseautage professionnel pour l'ensemble de la fonction publique. Vous pouvez vous inscrire à GCconnex en cliquant sur le lien suivant %s",
 
 

--- a/mod/cp_notifications/views/default/cp_notifications/email_template.php
+++ b/mod/cp_notifications/views/default/cp_notifications/email_template.php
@@ -421,11 +421,11 @@ switch ($msg_type) {
 
 
 	case 'cp_friend_invite': // link
-		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_invite_new_user:title',array(),'en');
-		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_invite_new_user:title',array(),'fr');
-
-		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_invite_new_user:description',array($vars['cp_join_url']),'en');
-		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_invite_new_user:description',array($vars['cp_join_url']),'fr');
+		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_invite_new_user:title',array($vars['cp_from_user']),'en');
+		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_invite_new_user:title',array($vars['cp_from_user']),'fr');
+        //Nick - adding the msg to the 
+		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_invite_new_user:description',array($vars['cp_join_url']),'en') . ' <br> ' . $vars['cp_msg'];
+		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_invite_new_user:description',array($vars['cp_join_url']),'fr'). ' <br> ' . $vars['cp_msg'];
 
 		break;
 


### PR DESCRIPTION
Added the personalised message and name of sender to the 'invite colleague to gcconnex' email.

Closes #559 