### PR TITLE
Official groups - Phase 1 - Ability to mark groups as official

### DIFF
--- a/mod/gc_official_groups/actions/add_off_group.php
+++ b/mod/gc_official_groups/actions/add_off_group.php
@@ -11,7 +11,9 @@ $guid = (int) get_input('guid');
 
 $group = get_entity($guid);
 
-if($group->official_group){
+//Make sure it is a group
+if($group instanceof ElggGroup){
+    if($group->official_group){
     if($group->official_group == true){
        echo json_encode([
         'confirm' =>'I am already official',
@@ -34,3 +36,11 @@ if($group->official_group){
 echo json_encode([
     'confirm' =>$guid,
 ]);*/
+    
+}else{
+    echo json_encode([
+        'confirm' =>'This aint no group',
+        'color'=>'red',
+    ]);
+    
+}

--- a/mod/gc_official_groups/actions/add_off_group.php
+++ b/mod/gc_official_groups/actions/add_off_group.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+* This action adds the official group meta data to a group.
+*
+* @version 1.0
+* @author Nick
+*/
+
+$guid = (int) get_input('guid');
+
+$group = get_entity($guid);
+
+if($group->official_group){
+    if($group->official_group == true){
+       echo json_encode([
+        'confirm' =>'I am already official',
+           'color'=>'red',
+       ]); 
+    }else if($group->official_group == false){
+        echo json_encode([
+        'confirm' =>'At one point I was official and then my status was removed but now i am official again',
+            'color'=>'green',
+       ]); 
+    }
+}else{
+    $group->official_group = true;
+    echo json_encode([
+        'confirm' =>'This group is now official',
+        'color'=>'green',
+    ]);
+}
+/*
+echo json_encode([
+    'confirm' =>$guid,
+]);*/

--- a/mod/gc_official_groups/actions/remove_off_group.php
+++ b/mod/gc_official_groups/actions/remove_off_group.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+* This action removes the official group meta data to a group.
+*
+* @version 1.0
+* @author Nick
+*/
+
+
+$guid = (int) get_input('guid');
+
+$group = get_entity($guid);
+
+if($group->official_group){
+    $group->official_group = false;
+   system_message('Official Status Removed');
+}

--- a/mod/gc_official_groups/graphics/official_check.svg
+++ b/mod/gc_official_groups/graphics/official_check.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 26.7 24.5" style="enable-background:new 0 0 26.7 24.5;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#468092;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st1{fill:#468092;}
+</style>
+<g id="XMLID_3_">
+	<g id="XMLID_6_">
+		<path id="XMLID_11_" class="st0" d="M5,6.6l6.9-4c0.7-0.4,1.6-0.4,2.2,0l6.9,4c0.7,0.4,1.1,1.1,1.1,1.9v7.9c0,0.8-0.4,1.5-1.1,1.9
+			l-6.9,4c-0.7,0.4-1.6,0.4-2.2,0l-6.9-4c-0.7-0.4-1.1-1.1-1.1-1.9V8.6C3.9,7.8,4.3,7,5,6.6z"/>
+	</g>
+	<g id="XMLID_2_">
+		<path id="XMLID_20_" class="st1" d="M19.9,10.3L13.2,17L12,18.2c-0.2,0.2-0.4,0.3-0.6,0.3c-0.2,0-0.5-0.1-0.6-0.3L9.5,17l-3.3-3.3
+			C6,13.4,5.9,13.2,5.9,13s0.1-0.5,0.3-0.6l1.3-1.3c0.2-0.2,0.4-0.3,0.6-0.3c0.2,0,0.5,0.1,0.6,0.3l2.7,2.7l6.1-6.1
+			c0.2-0.2,0.4-0.3,0.6-0.3c0.2,0,0.5,0.1,0.6,0.3L19.9,9c0.2,0.2,0.3,0.4,0.3,0.6C20.2,9.9,20.1,10.1,19.9,10.3z"/>
+	</g>
+</g>
+</svg>

--- a/mod/gc_official_groups/languages/en.php
+++ b/mod/gc_official_groups/languages/en.php
@@ -1,0 +1,5 @@
+<?php
+return array(
+    'gc_off_group:badge_text' =>"Official Group",
+
+);

--- a/mod/gc_official_groups/languages/fr.php
+++ b/mod/gc_official_groups/languages/fr.php
@@ -1,0 +1,5 @@
+<?php
+return array(
+    'gc_off_group:badge_text' =>"Groupe Officiel",
+
+);

--- a/mod/gc_official_groups/manifest.xml
+++ b/mod/gc_official_groups/manifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<plugin_manifest xmlns="http://www.elgg.org/plugin_manifest/1.8">
+  <name>GC - Official Groups</name>
+  <id>gc_official_groups</id>
+  <author>Government of Canada</author>
+  <version>1.0</version>
+	<category>social</category>
+  <description>Allows site admins to flag groups as official groups recognized by the site.</description>
+  <website>http://www.canada.ca</website>
+	<copyright>Her Majesty the Queen in Right of Canada, 2015</copyright>
+	<license>Creative Commons Attribution 3.0 Unported License</license>
+  <requires>
+    <type>elgg_release</type>
+    <version>1.9</version>
+  </requires>
+</plugin_manifest>

--- a/mod/gc_official_groups/start.php
+++ b/mod/gc_official_groups/start.php
@@ -17,6 +17,7 @@ function gc_official_group_init(){
     
     elgg_register_action('remove_off_group', elgg_get_plugins_path() .'gc_official_groups/actions/remove_off_group.php',"admin");
     
+    //Add CSS styles
     elgg_extend_view('css/elgg', 'css/official_groups');
     
     

--- a/mod/gc_official_groups/start.php
+++ b/mod/gc_official_groups/start.php
@@ -17,7 +17,9 @@ function gc_official_group_init(){
     
     elgg_extend_view('css/elgg', 'css/official_groups');
     
+    
     //Extend the summary view to add the official badge
     elgg_extend_view('object/elements/summary', 'object/elements/official_badge', 400);
+    elgg_extend_view('page/layouts/one_sidebar', 'object/elements/badge_group_profile',400);
     
 }

--- a/mod/gc_official_groups/start.php
+++ b/mod/gc_official_groups/start.php
@@ -15,6 +15,8 @@ function gc_official_group_init(){
     //Register the actions
     elgg_register_action('add_off_group', elgg_get_plugins_path() .'gc_official_groups/actions/add_off_group.php',"admin");
     
+    elgg_register_action('remove_off_group', elgg_get_plugins_path() .'gc_official_groups/actions/remove_off_group.php',"admin");
+    
     elgg_extend_view('css/elgg', 'css/official_groups');
     
     

--- a/mod/gc_official_groups/start.php
+++ b/mod/gc_official_groups/start.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+* GC Official groups - Allows site admins to flag groups as official recognized by the site
+*
+* @version 1.0
+* @author Nick
+*/
+
+//Init
+elgg_register_event_handler('init','system','gc_official_group_init');
+
+function gc_official_group_init(){
+    
+    //Register the actions
+    elgg_register_action('add_off_group', elgg_get_plugins_path() .'gc_official_groups/actions/add_off_group.php',"admin");
+    
+    elgg_extend_view('css/elgg', 'css/official_groups');
+    
+    //Extend the summary view to add the official badge
+    elgg_extend_view('object/elements/summary', 'object/elements/official_badge', 400);
+    
+}

--- a/mod/gc_official_groups/start.php
+++ b/mod/gc_official_groups/start.php
@@ -24,5 +24,5 @@ function gc_official_group_init(){
     //Extend the summary view to add the official badge
     elgg_extend_view('object/elements/summary', 'object/elements/official_badge', 400);
     elgg_extend_view('page/layouts/one_sidebar', 'object/elements/badge_group_profile',400);
-    
+    elgg_extend_view('groups/edit', 'page/elements/add_off_edit', 330);
 }

--- a/mod/gc_official_groups/views/default/css/official_groups.php
+++ b/mod/gc_official_groups/views/default/css/official_groups.php
@@ -11,6 +11,5 @@
          max-height:25px;
          max-width:25px;
          top:3px;
-         position: relative;
          margin-right:3px;
      }

--- a/mod/gc_official_groups/views/default/css/official_groups.php
+++ b/mod/gc_official_groups/views/default/css/official_groups.php
@@ -1,0 +1,16 @@
+<?php
+/*
+* Custom Styles for the official group mod
+*/
+ ?>
+
+
+ /* <style> /**/
+     
+     .official-check{
+         max-height:25px;
+         max-width:25px;
+         top:3px;
+         position: relative;
+         margin-right:3px;
+     }

--- a/mod/gc_official_groups/views/default/css/official_groups.php
+++ b/mod/gc_official_groups/views/default/css/official_groups.php
@@ -1,6 +1,9 @@
 <?php
 /*
 * Custom Styles for the official group mod
+*
+* @version 1.0
+* @author Nick
 */
  ?>
 

--- a/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
+++ b/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
@@ -19,7 +19,7 @@ $group = get_entity(elgg_get_page_owner_guid());
     $(document).ready(function(){
         //alert('good to go bb');
         var badge_link = elgg.normalize_url() +'mod/gc_official_groups/graphics/official_check.svg';
-        $('.group-title').prepend('<img src="'+badge_link+'" style="max-width: 26px;" title="official group">');
+        $('.group-title').prepend('<img src="'+badge_link+'" style="max-width: 26px;" title="<?php echo elgg_echo('gc_off_group:badge_text'); ?>">');
     })
 </script>
 

--- a/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
+++ b/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
@@ -1,4 +1,10 @@
 <?php
+/*
+* If we are on a group profile page, add the badge graphic with javascript
+*
+* @version 1.0
+* @author Nick
+*/
 
 if(elgg_in_context('group_profile') || elgg_instanceof(elgg_get_page_owner_entity(), 'group')){
 //Wrap this view in the context of group profile

--- a/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
+++ b/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
@@ -19,7 +19,7 @@ $group = get_entity(elgg_get_page_owner_guid());
     $(document).ready(function(){
         //alert('good to go bb');
         var badge_link = elgg.normalize_url() +'mod/gc_official_groups/graphics/official_check.svg';
-        $('.group-title').prepend('<img src="'+badge_link+'" style="max-width: 26px;" title="<?php echo elgg_echo('gc_off_group:badge_text'); ?>">');
+        $('.group-title').prepend('<img src="'+badge_link+'" style="max-width: 26px; max-height: 26px;" title="<?php echo elgg_echo('gc_off_group:badge_text'); ?>">');
     })
 </script>
 

--- a/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
+++ b/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
@@ -1,0 +1,26 @@
+<?php
+
+if(elgg_in_context('group_profile') || elgg_instanceof(elgg_get_page_owner_entity(), 'group')){
+//Wrap this view in the context of group profile
+
+
+$group = get_entity(elgg_get_page_owner_guid());
+    if($group->official_group){
+        
+?>
+
+<script>
+    $(document).ready(function(){
+        //alert('good to go bb');
+        var badge_link = elgg.normalize_url() +'mod/gc_official_groups/graphics/official_check.svg';
+        $('.group-title').prepend('<img src="'+badge_link+'" style="max-width: 26px;" title="official group">');
+    })
+</script>
+
+
+<?php 
+ }
+}
+
+?>
+

--- a/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
+++ b/mod/gc_official_groups/views/default/object/elements/badge_group_profile.php
@@ -5,7 +5,7 @@ if(elgg_in_context('group_profile') || elgg_instanceof(elgg_get_page_owner_entit
 
 
 $group = get_entity(elgg_get_page_owner_guid());
-    if($group->official_group){
+    if($group->official_group == true){
         
 ?>
 

--- a/mod/gc_official_groups/views/default/object/elements/official_badge.php
+++ b/mod/gc_official_groups/views/default/object/elements/official_badge.php
@@ -4,5 +4,5 @@ $entity = $vars['entity'];
 //Tests if the entity is an official group
 if($entity->official_group){
    
-echo '<object class="official-check" type="image/svg+xml" data="'.elgg_get_site_url().'mod/gc_official_groups/graphics/official_check.svg"></object>'; 
+echo '<img class="official-check" style="max-width: 26px;" title="official group"  src="'.elgg_get_site_url().'mod/gc_official_groups/graphics/official_check.svg">'; 
 }

--- a/mod/gc_official_groups/views/default/object/elements/official_badge.php
+++ b/mod/gc_official_groups/views/default/object/elements/official_badge.php
@@ -10,5 +10,5 @@ $entity = $vars['entity'];
 //Tests if the entity is an official group
 if($entity->official_group == true){
    
-echo '<img class="official-check" style="max-width: 26px;" title="official group"  src="'.elgg_get_site_url().'mod/gc_official_groups/graphics/official_check.svg">'; 
+echo '<img class="official-check" style="max-width: 26px;" title="'. elgg_echo('gc_off_group:badge_text') .'"  src="'.elgg_get_site_url().'mod/gc_official_groups/graphics/official_check.svg">'; 
 }

--- a/mod/gc_official_groups/views/default/object/elements/official_badge.php
+++ b/mod/gc_official_groups/views/default/object/elements/official_badge.php
@@ -1,0 +1,8 @@
+<?php
+
+$entity = $vars['entity'];
+//Tests if the entity is an official group
+if($entity->official_group){
+   
+echo '<object class="official-check" type="image/svg+xml" data="'.elgg_get_site_url().'mod/gc_official_groups/graphics/official_check.svg"></object>'; 
+}

--- a/mod/gc_official_groups/views/default/object/elements/official_badge.php
+++ b/mod/gc_official_groups/views/default/object/elements/official_badge.php
@@ -1,4 +1,10 @@
 <?php
+/*
+* Displays the official check in the group summary view
+*
+* @version 1.0
+* @author Nick
+*/
 
 $entity = $vars['entity'];
 //Tests if the entity is an official group

--- a/mod/gc_official_groups/views/default/object/elements/official_badge.php
+++ b/mod/gc_official_groups/views/default/object/elements/official_badge.php
@@ -2,7 +2,7 @@
 
 $entity = $vars['entity'];
 //Tests if the entity is an official group
-if($entity->official_group){
+if($entity->official_group == true){
    
 echo '<img class="official-check" style="max-width: 26px;" title="official group"  src="'.elgg_get_site_url().'mod/gc_official_groups/graphics/official_check.svg">'; 
 }

--- a/mod/gc_official_groups/views/default/page/elements/add_off_edit.php
+++ b/mod/gc_official_groups/views/default/page/elements/add_off_edit.php
@@ -1,0 +1,10 @@
+<?php
+
+
+$user = elgg_get_logged_in_user_entity();
+
+if (!empty($user) && $user->isAdmin()) {
+	$group = elgg_extract("entity", $vars);
+    
+    echo $group->guid;
+}

--- a/mod/gc_official_groups/views/default/page/elements/add_off_group.php
+++ b/mod/gc_official_groups/views/default/page/elements/add_off_group.php
@@ -7,11 +7,13 @@
 */
 
 $body = '<label for="group_url">Add Official Group</label>';
+$body .= '<div>Add the url to the group profile and click Add Group - ex: https://gcconnex.gc.ca/groups/profile/1234567/group-name</div>';
 $body .= '<div class="off-group-add-feedback"></div>';
 $body .= elgg_view('input/text', array(
     'name'=>'group_url',
     'id' => 'group_url',
     'class'=>'group-url',
+    'placeholder'=>'https://gcconnex.gc.ca/groups/profile/1234567/group-name',
 ));
 
 

--- a/mod/gc_official_groups/views/default/page/elements/add_off_group.php
+++ b/mod/gc_official_groups/views/default/page/elements/add_off_group.php
@@ -1,0 +1,25 @@
+<?php
+/*
+* A quick form of an input and a button to put in the url of the group the site admin wants to make offical
+*
+* @version 1.0
+* @author Nick
+*/
+
+$body = '<label for="group_url">Add Official Group</label>';
+$body .= '<div class="off-group-add-feedback"></div>';
+$body .= elgg_view('input/text', array(
+    'name'=>'group_url',
+    'id' => 'group_url',
+    'class'=>'group-url',
+));
+
+
+
+$body .= elgg_view('output/url', array(
+    'text'=>'Add Group',
+    'href'=>'#',
+    'id' => 'add_group_btn',
+    'class'=>'btn elgg-button elgg-button-submit',
+));
+echo $body;

--- a/mod/gc_official_groups/views/default/page/elements/add_off_group.php
+++ b/mod/gc_official_groups/views/default/page/elements/add_off_group.php
@@ -5,10 +5,12 @@
 * @version 1.0
 * @author Nick
 */
-
+//Label with some basic instructions
 $body = '<label for="group_url">Add Official Group</label>';
 $body .= '<div>Add the url to the group profile and click Add Group - ex: https://gcconnex.gc.ca/groups/profile/1234567/group-name</div>';
 $body .= '<div class="off-group-add-feedback"></div>';
+
+//Form
 $body .= elgg_view('input/text', array(
     'name'=>'group_url',
     'id' => 'group_url',
@@ -17,7 +19,7 @@ $body .= elgg_view('input/text', array(
 ));
 
 
-
+//Button
 $body .= elgg_view('output/url', array(
     'text'=>'Add Group',
     'href'=>'#',

--- a/mod/gc_official_groups/views/default/page/elements/off_group_table.php
+++ b/mod/gc_official_groups/views/default/page/elements/off_group_table.php
@@ -6,7 +6,7 @@
 * @author Nick
 */
 
-
+//Grab the groups with the official group = true metadata
 $group_entity_list = elgg_get_entities_from_metadata(array(
     'type'=>'group',
     'limit'=>0,
@@ -18,14 +18,16 @@ $group_entity_list = elgg_get_entities_from_metadata(array(
 
 echo '<table class="off-group-table">';
 echo '<tr><th>Group</th><th>Owner</th><th>Manage</th></tr>';
-//echo $group_entity_list;
+
 foreach($group_entity_list as $group){
-    
+    //Get the info for the group
     $user = $group->getOwnerEntity();
+    //Get the owner's email incase we need to contact them
     $mail_link = elgg_view('output/url', array(
         'text'=>$user->email,
         'href'=>'mailto:'.$user->email,
     ));
+    //Link to remove official status
     $remove_link = elgg_view('output/url', array(
         'text'=>'Remove Status',
         'href'=>'action/remove_off_group?guid='.$group->guid,

--- a/mod/gc_official_groups/views/default/page/elements/off_group_table.php
+++ b/mod/gc_official_groups/views/default/page/elements/off_group_table.php
@@ -1,0 +1,8 @@
+<?php
+/*
+* Creates a table of eixisting official groups for admins to manage
+*
+* @version 1.0
+* @author Nick
+*/
+

--- a/mod/gc_official_groups/views/default/page/elements/off_group_table.php
+++ b/mod/gc_official_groups/views/default/page/elements/off_group_table.php
@@ -22,12 +22,20 @@ echo '<tr><th>Group</th><th>Owner</th><th>Manage</th></tr>';
 foreach($group_entity_list as $group){
     
     $user = $group->getOwnerEntity();
-    
+    $mail_link = elgg_view('output/url', array(
+        'text'=>$user->email,
+        'href'=>'mailto:'.$user->email,
+    ));
+    $remove_link = elgg_view('output/url', array(
+        'text'=>'Remove Status',
+        'href'=>'action/remove_off_group?guid='.$group->guid,
+        'is_action'=>true,
+    ));
     echo '<tr>';
     $test = $group->name .' - ' .$group->guid . ' - ' .$user->name;
     echo '<td>'.$group->name.'</td>';
-    echo '<td>'.$user->name.' - '.$user->email.'</td>';
-    echo '<td><a href="#">Remove Status</a></td>';
+    echo '<td>'.$user->name.' - '.$mail_link.'</td>';
+    echo '<td>'.$remove_link.'</td>';
     echo '</tr>';
 }
 

--- a/mod/gc_official_groups/views/default/page/elements/off_group_table.php
+++ b/mod/gc_official_groups/views/default/page/elements/off_group_table.php
@@ -6,3 +6,49 @@
 * @author Nick
 */
 
+
+$group_entity_list = elgg_get_entities_from_metadata(array(
+    'type'=>'group',
+    'limit'=>0,
+    'metadata_name_value_pairs'=> array(
+        'name'=>'official_group',
+        'value'=>true,
+    ),
+));
+
+echo '<table class="off-group-table">';
+echo '<tr><th>Group</th><th>Owner</th><th>Manage</th></tr>';
+//echo $group_entity_list;
+foreach($group_entity_list as $group){
+    
+    $user = $group->getOwnerEntity();
+    
+    echo '<tr>';
+    $test = $group->name .' - ' .$group->guid . ' - ' .$user->name;
+    echo '<td>'.$group->name.'</td>';
+    echo '<td>'.$user->name.' - '.$user->email.'</td>';
+    echo '<td><a href="#">Remove Status</a></td>';
+    echo '</tr>';
+}
+
+echo '</table>';
+?>
+
+<style>
+    .off-group-table{
+        width:100%;
+        border: 1px solid #ddd;
+        margin-bottom:5px;
+        padding: 3px;
+    }
+    .off-group-table th{
+        font-weight: bold;
+        font-size: 16px;
+        border-bottom: 3px solid #ddd;
+        padding:6px;
+    }
+    .off-group-table td{
+        border: 1px solid #ddd;
+        padding:6px;
+    }
+</style>

--- a/mod/gc_official_groups/views/default/page/elements/off_group_table.php
+++ b/mod/gc_official_groups/views/default/page/elements/off_group_table.php
@@ -15,13 +15,19 @@ $group_entity_list = elgg_get_entities_from_metadata(array(
         'value'=>true,
     ),
 ));
-
+echo '<h3>Current Official Groups</h3>';
 echo '<table class="off-group-table">';
 echo '<tr><th>Group</th><th>Owner</th><th>Manage</th></tr>';
 
 foreach($group_entity_list as $group){
     //Get the info for the group
     $user = $group->getOwnerEntity();
+    
+    $group_link = elgg_view('output/url', array(
+        'text'=>$group->name,
+        'href'=>$group->getUrl(),
+        'target'=>'_blank',
+    ));
     //Get the owner's email incase we need to contact them
     $mail_link = elgg_view('output/url', array(
         'text'=>$user->email,
@@ -35,7 +41,7 @@ foreach($group_entity_list as $group){
     ));
     echo '<tr>';
     $test = $group->name .' - ' .$group->guid . ' - ' .$user->name;
-    echo '<td>'.$group->name.'</td>';
+    echo '<td>'.$group_link.'</td>';
     echo '<td>'.$user->name.' - '.$mail_link.'</td>';
     echo '<td>'.$remove_link.'</td>';
     echo '</tr>';
@@ -49,6 +55,7 @@ echo '</table>';
         width:100%;
         border: 1px solid #ddd;
         margin-bottom:5px;
+        margin-top: 15px;
         padding: 3px;
     }
     .off-group-table th{

--- a/mod/gc_official_groups/views/default/plugins/gc_official_groups/settings.php
+++ b/mod/gc_official_groups/views/default/plugins/gc_official_groups/settings.php
@@ -1,0 +1,50 @@
+<?php
+/*
+* Formats the admin setting page to add official groups. Script takes the url and gets the guid out of it, performs the action and returns the feedback
+*
+* @version 1.0
+* @author Nick
+*/
+
+$body = elgg_view('page/elements/add_off_group');
+
+
+echo $body;
+
+?>
+
+<script>
+$(document).ready(function(){
+    var group_url;
+    $('#group_url').on('blur', function(){
+        //This grabs the value of the text input
+        group_url = $(this).val();
+    })
+    $('#add_group_btn').on('click', function(){
+        //alert(group_url);
+        
+        var group_guid_array = group_url.split("/");
+        var group_guid = group_guid_array.slice(0,-1);
+        group_guid = parseInt(group_guid.slice(-1)[0]);
+        console.log(group_guid);
+        
+        if(group_guid){
+            //If we get a guid we can work with we'll send it to the action
+            elgg.action('add_off_group',{
+                data:{'guid':group_guid},
+                success: function(data){
+                    //Feedback gets sent back
+                    $('.off-group-add-feedback').text(data.output.confirm);
+                    $('.off-group-add-feedback').css({"color":data.output.color,});
+                    console.log(data.output.confirm);
+                }
+            })
+        }else{
+            //This ain't no GUID I ere heard of
+            console.log('aint no number i ever seen you dun goofed');
+        }
+        
+
+    });
+})
+</script>

--- a/mod/gc_official_groups/views/default/plugins/gc_official_groups/settings.php
+++ b/mod/gc_official_groups/views/default/plugins/gc_official_groups/settings.php
@@ -8,6 +8,7 @@
 
 $body = elgg_view('page/elements/add_off_group');
 
+$body .= elgg_view('page/elements/off_group_table');
 
 echo $body;
 

--- a/mod/gc_official_groups/views/default/plugins/gc_official_groups/settings.php
+++ b/mod/gc_official_groups/views/default/plugins/gc_official_groups/settings.php
@@ -23,7 +23,7 @@ $(document).ready(function(){
         group_url = $(this).val();
     })
     $('#add_group_btn').on('click', function(){
-        
+        $(this).text('Thinking ...');
         //Take the url and split it up to get the group guid
         var group_guid_array = group_url.split("/");
         var group_guid = group_guid_array.slice(0,-1);
@@ -37,11 +37,13 @@ $(document).ready(function(){
                     //Feedback gets sent back
                     $('.off-group-add-feedback').text(data.output.confirm);
                     $('.off-group-add-feedback').css({"color":data.output.color,});
+                    $('#add_group_btn').text('Add Group');
                 }
             })
         }else{
             //This ain't no GUID I ere heard of
-            alert("I can't seem to find the group from this URL. Make sure you are grabbing the group's profile URL"));
+            alert("I can't seem to find the group from this URL. Make sure you are grabbing the group's profile URL");
+            $('#add_group_btn').text('Add Group');
         }
         
 

--- a/mod/gc_official_groups/views/default/plugins/gc_official_groups/settings.php
+++ b/mod/gc_official_groups/views/default/plugins/gc_official_groups/settings.php
@@ -6,8 +6,9 @@
 * @author Nick
 */
 
+//Our happy little form
 $body = elgg_view('page/elements/add_off_group');
-
+//Table of official groups
 $body .= elgg_view('page/elements/off_group_table');
 
 echo $body;
@@ -22,12 +23,11 @@ $(document).ready(function(){
         group_url = $(this).val();
     })
     $('#add_group_btn').on('click', function(){
-        //alert(group_url);
         
+        //Take the url and split it up to get the group guid
         var group_guid_array = group_url.split("/");
         var group_guid = group_guid_array.slice(0,-1);
         group_guid = parseInt(group_guid.slice(-1)[0]);
-        console.log(group_guid);
         
         if(group_guid){
             //If we get a guid we can work with we'll send it to the action
@@ -37,12 +37,11 @@ $(document).ready(function(){
                     //Feedback gets sent back
                     $('.off-group-add-feedback').text(data.output.confirm);
                     $('.off-group-add-feedback').css({"color":data.output.color,});
-                    console.log(data.output.confirm);
                 }
             })
         }else{
             //This ain't no GUID I ere heard of
-            console.log('aint no number i ever seen you dun goofed');
+            alert("I can't seem to find the group from this URL. Make sure you are grabbing the group's profile URL"));
         }
         
 


### PR DESCRIPTION
From the admin panel, site admins can add groups to a list of official groups. Currently this will add a check mark to the group title in the group list view and the group profile view. 

Search engine optimisation for these groups will be the next phase.

closes #584 